### PR TITLE
check status every second

### DIFF
--- a/Controller/Financing/Success.php
+++ b/Controller/Financing/Success.php
@@ -64,7 +64,7 @@ class Success extends \Magento\Framework\App\Action\Action implements CsrfAwareA
         if ($order->getId()) {
             $this->logger->info('Order Found found with quote:'.$quoteId);
         } else if(!empty($this->getTimeout())){
-            for($x = 0; $x < $this->getTimeout() ; $x++ ){
+            for($x = 0; $x < (int)$this->getTimeout() ; $x++ ){
                 $this->logger->info('Order not found with quote:'.$quoteId);
                 sleep(1);
                 $order   = $this->order->loadByAttribute('quote_id', $quoteId);

--- a/Controller/Financing/Success.php
+++ b/Controller/Financing/Success.php
@@ -46,7 +46,7 @@ class Success extends \Magento\Framework\App\Action\Action implements CsrfAwareA
             'payment/divido_financing/timeout_delay',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
-    
+
         return $timeout;
     }
 
@@ -63,10 +63,12 @@ class Success extends \Magento\Framework\App\Action\Action implements CsrfAwareA
 
         if ($order->getId()) {
             $this->logger->info('Order Found found with quote:'.$quoteId);
-        } else {
-            $this->logger->info('Order not found with quote:'.$quoteId);
-            sleep($this->getTimeout());
-            $order   = $this->order->loadByAttribute('quote_id', $quoteId);
+        } else if(!empty($this->getTimeout())){
+            for($x = 0; $x < $this->getTimeout() ; $x++ ){
+                $this->logger->info('Order not found with quote:'.$quoteId);
+                sleep(1);
+                $order   = $this->order->loadByAttribute('quote_id', $quoteId);
+            }
         }
 
         if($debug){

--- a/Controller/Financing/Success.php
+++ b/Controller/Financing/Success.php
@@ -68,6 +68,10 @@ class Success extends \Magento\Framework\App\Action\Action implements CsrfAwareA
                 $this->logger->info('Order not found with quote:'.$quoteId);
                 sleep(1);
                 $order   = $this->order->loadByAttribute('quote_id', $quoteId);
+                if($order->getId()){
+                    $this->logger->info('Order Found found with quote:'.$quoteId);
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Currently the order status is checked after the a sleep of the timeout in seconds.
This could result in the server prematurely cutting off the timeout

Instead check the order status every second and in a loop for the timout and break from the loop once the order id is found