### PR TITLE
Addes fixes to fetch only Order ID instead of an entire collection

### DIFF
--- a/Model/CreditRequest.php
+++ b/Model/CreditRequest.php
@@ -187,11 +187,14 @@ class CreditRequest implements CreditRequestInterface
                 array('method')
             )
             ->where('sop.method = ?', 'divido_financing');
-        $this->orderCollection->setOrder(
-            'created_at',
-            'desc'
-        );
-        $dividoOrderId = $this->orderCollection->getFirstItem()->getId();
+        $this->orderCollection->getSelect()
+            ->limit(1)
+            ->reset(\Zend_Db_Select::COLUMNS)
+            ->columns(['entity_id']);
+
+        $this->orderCollection->setOrder('created_at', 'desc');
+
+        $dividoOrderId = $this->orderCollection->getConnection()->fetchOne($this->orderCollection->getSelect());
 
         if (!empty($dividoOrderId)) {
             $order = $this->order->loadByAttribute('entity_id', $dividoOrderId);


### PR DESCRIPTION
- Removed un-necessary columns being fetched from the database
- Avoided loading a collection to fetch a single row value
- Used `fetchOne` instead of collection `getFirstItem()`
- Added `limit`

Resultant SQL:
```sql
SELECT
    `main_table`.`entity_id` 
FROM
    `sales_order` AS `main_table` 
    INNER JOIN
        `sales_order_payment` AS `sop` 
        ON main_table.entity_id = sop.parent_id 
WHERE
    (
        `quote_id` = '<quote_id>'
    )
    AND 
    (
        sop.method = 'divido_financing'
    )
ORDER BY
    `created_at` DESC LIMIT 1
```