### PR TITLE
Fix/include tax with shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will now be documented in this file.
 
-## [2.4.1] - 2021-02-03
+
+## [2.4.2] - 2021-03-23
+- fix: Do not create order on referred status
+
+## [2.4.1] - 2021-02-14
 - fix: Do not create order on referred status
 
 ## [2.4.0] - 2021-02-03

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -404,7 +404,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $totals = $quote->getTotals();
         $grandTotal = $totals['grand_total']->getValue();
         $deposit = round($depositAmount);
-        $shipping = $shipAddr->getShippingAmount() * 100;
+        $shipping = $quote->getShippingInclTax() * 100;
         if (! empty($shipping)) {
             $products[] = [
                 'type'     => 'product',

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -17,7 +17,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.4.1';
+    const VERSION            = '2.4.2';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
 
     private $config;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -404,7 +404,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $totals = $quote->getTotals();
         $grandTotal = $totals['grand_total']->getValue();
         $deposit = round($depositAmount);
-        $shipping = $quote->getShippingInclTax() * 100;
+        $shipping = $shipAddr->getShippingInclTax() * 100;
         if (! empty($shipping)) {
             $products[] = [
                 'type'     => 'product',

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "license": [
         "OSL-3.0"
     ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Divido_DividoFinancing" setup_version="2.4.1" active="true">
+	<module name="Divido_DividoFinancing" setup_version="2.4.2" active="true">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
Jira ticket: https://divido.atlassian.net/browse/SCB-397

I found this method which can be applied to the ShippingAddress object:
https://hotexamples.com/examples/magento.sales.model/Order/getShippingInclTax/php-order-getshippingincltax-method-examples.html

This branch has been tested successfully on magento2.dev.divido.com with a taxable good on Standard VAT e.g. (Impulse Duffle)