### PR TITLE
fix: filters out plans at checkout based on their min/max amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will now be documented in this file.
 
 
+## [2.4.3] - 2021-04-28
+- fix: filters out plans at checkout based on their min/max amount
+
 ## [2.4.2] - 2021-03-23
 - fix: Do not create order on referred status
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -279,6 +279,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             if ($planMinTotal < $plan->deposit->minimum_percentage) {
                 unset($plans[$key]);
             }
+            if($plan->credit_amount->minimum_amount > $grandTotal || $plan->credit_amount->maximum_amount < $grandTotal) {
+                unset($plans[$key]);
+            }
         }
 
         return $plans;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -17,7 +17,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.4.2';
+    const VERSION            = '2.4.3';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
 
     private $config;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "license": [
         "OSL-3.0"
     ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Divido_DividoFinancing" setup_version="2.4.2" active="true">
+	<module name="Divido_DividoFinancing" setup_version="2.4.3" active="true">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
Makes sure the checkout total falls between the set min/max amount in the credit amount settings for each finance plan within the merchant portal. 