### PR TITLE
chore: fix merchant sdk to v2.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "divido/merchant-sdk": "^2.4.1",
+        "divido/merchant-sdk": "2.5.1",
         "divido/merchant-sdk-guzzle-6": "^1.1"
         },
     "require-dev": {


### PR DESCRIPTION
As we introduce a breaking change to the merchant SDK, we ensure existing implementations don't update the version until the implementation has been adapted to the new version

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [ ] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
