### PR TITLE
chore: lock merchant-api-sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "license": [
         "OSL-3.0"
     ],
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "divido/merchant-sdk": "^2.4.1",
+        "divido/merchant-sdk": "2.5.1",
         "divido/merchant-sdk-guzzle-6": "^1.1"
         },
     "require-dev": {


### PR DESCRIPTION
Locks merchant API SDK to v2.5.1 before we release a breaking change in v2.6

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [ ] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
