### PR TITLE
feat: bumps merchant api sdk and implements

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -172,11 +172,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $this->logger->info('Environment URL ' . $environmentUrl);
         }
 
-        // Create what is needed to create and return a MerchantSDK Client
-        $client = new \GuzzleHttp\Client();
-
-        $httpClientWrapper = new \Divido\MerchantSDK\HttpClient\HttpClientWrapper(
-            new \Divido\MerchantSDKGuzzle6\GuzzleAdapter($client),
+        $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
             $environmentUrl,
             $apiKey
         );

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -11,7 +11,6 @@ use Magento\Framework\Exception\RuntimeException;
 use Magento\Framework\Phrase;
 use Magento\Framework\UrlInterface;
 use Divido\DividoFinancing\Helper\EndpointHealthCheckTrait;
-use Throwable;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -25,7 +24,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.6.0';
+    const VERSION            = '2.7.0';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
     const SHIPPING           = 'SHPNG';
     const DISCOUNT           = 'DSCNT';

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.6.1",
+    "version": "2.7.0",
     "license": [
         "OSL-3.0"
     ],
@@ -13,9 +13,8 @@
         }
     },
     "require": {
-        "divido/merchant-sdk": "2.5.1",
-        "divido/merchant-sdk-guzzle-6": "^1.1"
-        },
+        "divido/merchant-sdk": "^3.0.0"
+    },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
         "magento/core": "*",


### PR DESCRIPTION
Implements the most recent version of the merchant-api-sdk, which does away with the GuzzleAdapter dependency.
Adjusts the implementation of the sdk, for compatibility

### PR CHECKLIST

- [x] Ensure any new strings have been translated for import
- [x] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [x] The plugin version (currently as a const in the `Data.php`) has been updated
- [x] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
