### PR TITLE
fix: LM2-1544 ready status creation

### DIFF
--- a/Controller/Financing/Success.php
+++ b/Controller/Financing/Success.php
@@ -13,6 +13,8 @@ class Success extends \Magento\Framework\App\Action\Action implements CsrfAwareA
     private $order;
     private $quoteRepository;
 
+    const MIN_TIMEOUT = 30;
+
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
         \Magento\Checkout\Model\Session $checkoutSession,
@@ -46,7 +48,9 @@ class Success extends \Magento\Framework\App\Action\Action implements CsrfAwareA
             'payment/divido_financing/timeout_delay',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
-
+        if($timeout < self::MIN_TIMEOUT){
+            self::MIN_TIMEOUT;
+        }
         return $timeout;
     }
 

--- a/Controller/Financing/Success.php
+++ b/Controller/Financing/Success.php
@@ -44,14 +44,15 @@ class Success extends \Magento\Framework\App\Action\Action implements CsrfAwareA
 
     public function getTimeout()
     {
-        $timeout = $this->config->getValue(
+        $timeout = (int) $this->config->getValue(
             'payment/divido_financing/timeout_delay',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
-        if($timeout < self::MIN_TIMEOUT){
-            self::MIN_TIMEOUT;
-        }
-        return $timeout;
+        
+        return ($timeout < self::MIN_TIMEOUT)
+            ? self::MIN_TIMEOUT
+            : $timeout;
+
     }
 
     public function execute()

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -24,7 +24,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.7.0';
+    const VERSION            = '2.7.1';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
     const SHIPPING           = 'SHPNG';
     const DISCOUNT           = 'DSCNT';

--- a/Model/CreditRequest.php
+++ b/Model/CreditRequest.php
@@ -17,7 +17,8 @@ class CreditRequest implements CreditRequestInterface
         STATUS_FULFILLED     = 'FULFILLED',
         STATUS_REFERRED      = 'REFERRED',
         STATUS_SIGNED        = 'SIGNED',
-        CREATION_STATUS      = self::STATUS_SIGNED;
+        STATUS_READY        = 'READY',
+        CREATION_STATUS      = self::STATUS_READY;
 
     private $historyMessages = [
         self::STATUS_ACCEPTED      => 'Credit request accepted',
@@ -29,6 +30,7 @@ class CreditRequest implements CreditRequestInterface
         self::STATUS_FULFILLED     => 'Credit request fulfilled',
         self::STATUS_REFERRED      => 'Credit request referred by Underwriter, waiting for new status',
         self::STATUS_SIGNED        => 'Customer have signed all contracts',
+        self::STATUS_READY         => 'Application ready',
     ];
 
     private $noGo = [

--- a/Model/CreditRequest.php
+++ b/Model/CreditRequest.php
@@ -17,7 +17,7 @@ class CreditRequest implements CreditRequestInterface
         STATUS_FULFILLED     = 'FULFILLED',
         STATUS_REFERRED      = 'REFERRED',
         STATUS_SIGNED        = 'SIGNED',
-        STATUS_READY        = 'READY',
+        STATUS_READY         = 'READY',
         CREATION_STATUS      = self::STATUS_READY;
 
     private $historyMessages = [
@@ -268,11 +268,12 @@ class CreditRequest implements CreditRequestInterface
                 $this->logger->debug('Divido: Create order');
             }
 
-            $quote = $this->quote->loadActive($quoteId);
+            $quote = $this->quote->load($quoteId);
             if (! $quote->getCustomerId()) {
                 $quote->setCheckoutMethod(\Magento\Quote\Model\QuoteManagement::METHOD_GUEST);
-                $quote->save();
             }
+            $quote->setIsActive(true);
+            $quote->save();
 
             //If cart value is different do not place order
             $totals = $quote->getTotals();
@@ -335,7 +336,7 @@ class CreditRequest implements CreditRequestInterface
 
         $lookup->save();
 
-        if ($data->status == self::STATUS_SIGNED) {
+        if ($data->status == self::CREATION_STATUS) {
             $this->logger->info('Divido: Escalate order');
 
             if ($debug) {
@@ -353,7 +354,7 @@ class CreditRequest implements CreditRequestInterface
             $order->setState(\Magento\Sales\Model\Order::STATE_PROCESSING, true);
             $order->setStatus($status);
 
-            //Send Email only when order is signed by customer.
+            //Send Email only when order has achieved creation status.
             $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
             $objectManager->create('Magento\Sales\Model\OrderNotifier')->notify($order);
         }

--- a/Model/CreditRequest.php
+++ b/Model/CreditRequest.php
@@ -16,7 +16,8 @@ class CreditRequest implements CreditRequestInterface
         STATUS_DEPOSIT_PAID  = 'DEPOSIT-PAID',
         STATUS_FULFILLED     = 'FULFILLED',
         STATUS_REFERRED      = 'REFERRED',
-        STATUS_SIGNED        = 'SIGNED';
+        STATUS_SIGNED        = 'SIGNED',
+        CREATION_STATUS      = self::STATUS_SIGNED;
 
     private $historyMessages = [
         self::STATUS_ACCEPTED      => 'Credit request accepted',
@@ -229,8 +230,6 @@ class CreditRequest implements CreditRequestInterface
             $this->eventManager->dispatch('divido_financing_quote_referred', ['quote_id' => $quoteId]);
         }
 
-        $creationStatus = self::STATUS_SIGNED;
-
         //Check if Divido order already exists (as with same quoteID, other orders with different payment method may be present with status as cancelled)
         //Divido order not exists
         $isOrderExists = false;
@@ -251,7 +250,7 @@ class CreditRequest implements CreditRequestInterface
 
         if (
             !$isOrderExists
-            && $data->status != $creationStatus
+            && $data->status != self::CREATION_STATUS
             && $data->status != self::STATUS_REFERRED
         ) {
             if ($debug) {
@@ -260,7 +259,7 @@ class CreditRequest implements CreditRequestInterface
             return $this->webhookResponse();
         }
         $this->logger->info('Application Update ----- test' );
-        if (! $isOrderExists && ($data->status == $creationStatus)) {
+        if (! $isOrderExists && ($data->status == self::CREATION_STATUS)) {
 
             $this->logger->info('order does not exist' );
             if ($debug) {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -89,7 +89,7 @@
                     <comment><![CDATA[Allows users to swap between lightbox popup and large calculator view ]]></comment>
                 </field>
                 <field id="order_status" translate="label" type="select" sortOrder="22" showInDefault="1" showInWebsite="1" showInStore="0">
-                    <label>New order status when Signed</label>
+                    <label>New order status on Completion</label>
 				    <source_model>Magento\Sales\Model\Config\Source\Order\Status</source_model>
                 </field>
                 <field id="auto_fulfilment" translate="label" type="select" sortOrder="23" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,7 +10,7 @@
                 <min_order_total>0.50</min_order_total>
                 <max_loan_amount>25000</max_loan_amount>
                 <currency>GBP,EUR</currency>
-                <timeout_delay>7</timeout_delay>
+                <timeout_delay>30</timeout_delay>
                 <can_use_internal>0</can_use_internal>
                 <allowspecific>1</allowspecific>
                 <specificcountry>GB,FI</specificcountry>


### PR DESCRIPTION
This is a twofold fix. The first is to ensure orders are created by default on the READY webhook rather than signed. Previously we would create orders when the SIGNED webhook was received in order to ameliorate a race condition, whereby customers would return to the store before the order had been created by the READY webhook. This was still hit and miss, and out-keeping with the status quo across the e-com platform stack. What's more, we don't receive a SIGNED webhook from the Novuna journey, so it's doubly necessary to change this. This fix looks to return the order creation back to the READY webhook, and increases the poll time when the customer returns to the store.

This patch also fixes an issue whereby stale quotes would be ignored when the webhook turns them into fully fledged orders. I'm not sure what the timeframe is for quotes to go stale, but it seems to be very short, so for long journeys like Novuna's, or indeed journeys which are deferred, or finished after an email prompt by the lender, the result would possibly be that the quote would be stale by completion. This fix ensures the quote is reactivated before converting it to an order.


### PR CHECKLIST

- [x] Ensure any new strings have been translated for import
- [x] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [x] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
