### PR TITLE
chore: bump plugin version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,5 @@
 - [ ] Ensure any new strings have been translated for import
 - [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
 - [ ] The plugin version (currently as a const in the `Data.php`) has been updated
+- [ ] The plugin version in `composer.json` has been updated
 - [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Bumps the plugin version so that the new release is reflected on packagist

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [ ] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
