### PR TITLE
feat: retrieves branding from first lender plan

### DIFF
--- a/Block/Head.php
+++ b/Block/Head.php
@@ -35,4 +35,9 @@ class Head extends \Magento\Framework\View\Element\Template
             return '[unknown]';
         }
     }
+
+    public function getBrandingJson()
+    {
+        return $this->helper->getBranding();
+    }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -186,8 +186,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getBranding()
     {
         $plans = $this->getGlobalSelectedPlans();
-        if(!$plans){
-            return 'null';
+        if(!$plans || !isset($plans[0]->lender->branding)){
+            return '{}';
         }
         $branding = $plans[0]->lender->branding;
         $branding->lender = $plans[0]->lender->name;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -24,7 +24,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.7.3';
+    const VERSION            = '2.8.0';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
     const SHIPPING           = 'SHPNG';
     const DISCOUNT           = 'DSCNT';

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -183,6 +183,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return new \Divido\MerchantSDK\Client($httpClientWrapper, $env);
     }
 
+    public function getBranding()
+    {
+        $plans = $this->getGlobalSelectedPlans();
+        if(!$plans){
+            return 'null';
+        }
+        $branding = $plans[0]->lender->branding;
+        $branding->lender = $plans[0]->lender->name;
+        return json_encode($branding);
+    }
+
     /*
     public function getConnection()
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.7.3",
+    "version": "2.8.0",
     "license": [
         "OSL-3.0"
     ],

--- a/view/frontend/templates/head.phtml
+++ b/view/frontend/templates/head.phtml
@@ -6,6 +6,7 @@
 <script> 
 __widgetConfig = {apiKey: '<?php echo $block->getDividoKey(); ?>'}
 var dividoEnv = '<?php echo $block->getPlatformEnv(); ?>';
+var dividoBranding = <?php echo $block->getBrandingJson(); ?>;
 </script>
 <script type="text/javascript" src="<?php echo $block->getScriptUrl(); ?>"></script>
 <script>// <![CDATA[

--- a/view/frontend/templates/head.phtml
+++ b/view/frontend/templates/head.phtml
@@ -5,8 +5,8 @@
 ?>
 <script> 
 __widgetConfig = {apiKey: '<?php echo $block->getDividoKey(); ?>'}
-var dividoEnv = '<?php echo $block->getPlatformEnv(); ?>';
-var dividoBranding = <?php echo $block->getBrandingJson(); ?>;
+const dividoEnv = '<?php echo $block->getPlatformEnv(); ?>';
+const dividoBranding = <?php echo $block->getBrandingJson(); ?>;
 </script>
 <script type="text/javascript" src="<?php echo $block->getScriptUrl(); ?>"></script>
 <script>// <![CDATA[

--- a/view/frontend/web/js/view/payment/method-renderer/divido-dividofinancing.js
+++ b/view/frontend/web/js/view/payment/method-renderer/divido-dividofinancing.js
@@ -59,20 +59,27 @@ define(
 
             getIconAttributes: function () {
                 let returnObj = {'style':'max-height:28px'};
-                switch (dividoEnv){
-                    case 'nordea':
-                        returnObj.src = 'https://cdn.divido.com/widget/themes/nordea/logo.png';
-                        returnObj.alt = 'Nordea'
-                        break;
-                    case 'ing':
-                        returnObj.src = 'https://lender-branding-prod.s3.eu-west-1.amazonaws.com/ing.png';
-                        returnObj.alt = 'ING PayCtrl';
-                        break;
-                    default:
-                        returnObj.style = 'display: none';
-                        break;
+
+                if(typeof dividoBranding.logo_url !== 'undefined'){
+                    returnObj.src = dividoBranding.logo_url;
+                    returnObj.alt = dividoBranding.lender;
+                    return returnObj;
+                }else{
+                    switch (dividoEnv){
+                        case 'nordea':
+                            returnObj.src = 'https://cdn.divido.com/widget/themes/nordea/logo.png';
+                            returnObj.alt = 'Nordea'
+                            break;
+                        case 'ing':
+                            returnObj.src = 'https://lender-branding-prod.s3.eu-west-1.amazonaws.com/ing.png';
+                            returnObj.alt = 'ING PayCtrl';
+                            break;
+                        default:
+                            returnObj.style = 'display: none';
+                            break;
+                    }
+                    return returnObj;
                 }
-                return returnObj;
             },
 
             getTransactionResults: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/divido-dividofinancing.js
+++ b/view/frontend/web/js/view/payment/method-renderer/divido-dividofinancing.js
@@ -63,7 +63,6 @@ define(
                 if(typeof dividoBranding !== 'undefined' && dividoBranding.logo_url){
                     returnObj.src = dividoBranding.logo_url;
                     returnObj.alt = dividoBranding.lender;
-                    return returnObj;
                 }else{
                     switch (dividoEnv){
                         case 'nordea':
@@ -78,8 +77,8 @@ define(
                             returnObj.style = 'display: none';
                             break;
                     }
-                    return returnObj;
                 }
+                return returnObj;
             },
 
             getTransactionResults: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/divido-dividofinancing.js
+++ b/view/frontend/web/js/view/payment/method-renderer/divido-dividofinancing.js
@@ -60,7 +60,7 @@ define(
             getIconAttributes: function () {
                 let returnObj = {'style':'max-height:28px'};
 
-                if(typeof dividoBranding.logo_url !== 'undefined'){
+                if(typeof dividoBranding !== 'undefined' && dividoBranding.logo_url){
                     returnObj.src = dividoBranding.logo_url;
                     returnObj.alt = dividoBranding.lender;
                     return returnObj;


### PR DESCRIPTION
This PR retrieves the lender branding from the first finance plan it receives from the merchant-api-pub, then uses it to display the lender branded logo at checkout, if it has been set. It fails over to the hardcoded logos otherwise. 

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [x] The plugin version (currently as a const in the `Data.php`) has been updated
- [x] The plugin version in `composer.json` has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
