### PR TITLE
feat: updates merchant reference as order ID

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -24,7 +24,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.8.1';
+    const VERSION            = '2.9.0';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
     const SHIPPING           = 'SHPNG';
     const DISCOUNT           = 'DSCNT';

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -611,18 +611,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         try{
             $sdk  = $this->getSdk();
-            $application = $sdk->applications()->getSingleApplication($applicationId);
-            $application = json_decode($application->getBody()->getContents());
-
-            $financePlanId =  $application->data->finance_plan->id;
-            $orderItems = $application->data->order_items;
-            $applicants = $application->data->applicants;
 
             $application    = (new \Divido\MerchantSDK\Models\Application())
                 ->withId($applicationId)
-                ->withFinancePlanId($financePlanId)
-                ->withApplicants($applicants)
-                ->withOrderItems($orderItems)
+                ->withApplicants(null)
+                ->withOrderItems(null)
+                ->withMerchantReference($orderId)
                 ->withMetadata([
                     "merchant_reference" => $orderId
                 ]);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.8.1",
+    "version": "2.9.0",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Sends the magento Order ID as our merchant reference once the order has been created on the platform.
Also removes an unnecessary API call which was used to plug information into the patch (unnecessarily). 

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [x] The plugin version (currently as a const in the `Data.php`) has been updated
- [x] The plugin version in `composer.json` has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
