### PR TITLE
fix: LM2-1855 address fields

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -24,7 +24,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.9.0';
+    const VERSION            = '2.9.1';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
     const SHIPPING           = 'SHPNG';
     const DISCOUNT           = 'DSCNT';

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -918,11 +918,18 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getAddressDetail($addressObject)
     {
-        $street = str_replace("\n", " ", $addressObject['street']);
-        $addressText     = implode(' ', [$street, $addressObject['city'],$addressObject['postcode']]);
+        $addressText     = implode(
+            ', ', 
+            array_merge(
+                explode("\n",$addressObject['street']), 
+                [$addressObject['city']]
+            )
+        );
         $addressArray = [
             'postcode' => $addressObject['postcode'],
-            'text'     => $addressText,
+            'text' => $addressText,
+            'street' => explode("\n",$addressObject['street'])[0],
+            'town' => $addressObject['city'] 
         ];
 
         return $addressArray;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Adds additional fields to the application address, whilst also removing the postcode from the text field, as suggested by Dom.

This is to obtain better results from Loqate.

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [ ] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] The plugin version in `composer.json` has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
