### PR TITLE
fix: installation woes

### DIFF
--- a/Block/Adminhtml/Order/Creditmemo/Create/Custom.php
+++ b/Block/Adminhtml/Order/Creditmemo/Create/Custom.php
@@ -66,7 +66,7 @@ class Custom extends \Magento\Backend\Block\Template
                     $returnApp['reasons'] = Data::REFUND_CANCEL_REASONS[$application->lender->app_name];
                 }
             } catch (\Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException $_){
-                $apiKeyError = _("It appears you are using a different API Key to the one used to create this application. Please revert to that API key if you wish to automatically request this amount is refunded");
+                $apiKeyError = __("It appears you are using a different API Key to the one used to create this application. Please revert to that API key if you wish to automatically request this amount is refunded");
                 $returnApp['notifications'] = [$apiKeyError];
             }
         }

--- a/Block/Adminhtml/Order/Creditmemo/Create/Custom.php
+++ b/Block/Adminhtml/Order/Creditmemo/Create/Custom.php
@@ -40,18 +40,18 @@ class Custom extends \Magento\Backend\Block\Template
         if ($code == Data::PAYMENT_METHOD && !empty($this->helper->getApiKey()) && $autoRefund) {
             try{
                 $application = $this->helper->getApplicationFromOrder($order);
-                $returnApp['refundable'] = $application['amounts']['refundable_amount'];
+                $returnApp['refundable'] = $application->amounts->refundable_amount;
                 $returnApp['notifications'][] = sprintf(
                     __("The de-facto amount refundable for this application is %s. Any refund attempt exceding this will be processed as a full refund for %s"),
                     $order->formatPrice($returnApp['refundable']/100),
                     $order->formatPrice($returnApp['refundable']/100)
                 );
 
-                if(in_array($application['lender']['app_name'], Data::NON_PARTIAL_LENDERS)){
+                if(in_array($application->lender->app_name, Data::NON_PARTIAL_LENDERS)){
                     $returnApp['notifications'][] = __("We are unable to request partial refunds from your lender");
                     $returnApp['partial_refundable'] = 0;
-                }elseif($application['finance_plan']['credit_amount']['minimum_amount'] > 0){
-                    $returnApp['partial_refundable'] = $application['amounts']['refundable_amount'] - $application['finance_plan']['credit_amount']['minimum_amount'];
+                }elseif($application->finance_plan->credit_amount->minimum_amount > 0){
+                    $returnApp['partial_refundable'] = $application->amounts->refundable_amount - $application->finance_plan->credit_amount->minimum_amount;
                     $returnApp['notifications'][] = sprintf(
                         __("If you are making a partial refund, the maximum that can be refunded (before reaching this finance plan's minimum credit limit) is %s"), 
                         $order->formatPrice($returnApp['partial_refundable']/100)
@@ -60,10 +60,10 @@ class Custom extends \Magento\Backend\Block\Template
                
                 $returnApp['notifications'][] = __("Please turn off automatic refunds in the Powered By Divido plugin if you wish to create refunds outside of the above scope");
 
-                if(array_key_exists($application['lender']['app_name'], Data::REFUND_CANCEL_REASONS)){
+                if(array_key_exists($application->lender->app_name, Data::REFUND_CANCEL_REASONS)){
                     $returnApp['reason_notification'] = __("You must specify one of the following reasons for the refund to be successfully processed");
                     $returnApp['reason_title'] = __("Refund Reason");
-                    $returnApp['reasons'] = Data::REFUND_CANCEL_REASONS[$application['lender']['app_name']];
+                    $returnApp['reasons'] = Data::REFUND_CANCEL_REASONS[$application->lender->app_name];
                 }
             } catch (\Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException $_){
                 $apiKeyError = _("It appears you are using a different API Key to the one used to create this application. Please revert to that API key if you wish to automatically request this amount is refunded");

--- a/Block/Adminhtml/Order/View/Custom.php
+++ b/Block/Adminhtml/Order/View/Custom.php
@@ -52,8 +52,8 @@ class Custom extends \Magento\Backend\Block\Template
             ];
             try{
                 $application = $this->helper->getApplicationFromOrder($order);
-                if(array_key_exists($application['lender']['app_name'], Data::REFUND_CANCEL_REASONS)){
-                    $cancellation['reasons'] = Data::REFUND_CANCEL_REASONS[$application['lender']['app_name']];
+                if(array_key_exists($application->lender->app_name, Data::REFUND_CANCEL_REASONS)){
+                    $cancellation['reasons'] = Data::REFUND_CANCEL_REASONS[$application->lender->app_name];
                 }
             } catch (\Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException $_){
                 $cancellation['notification'] = __("It appears the cancellation was created with a different API key to the one currently in use. Pleae revert to that API Key if you wish to notify the lender");

--- a/Block/Adminhtml/Order/View/Custom.php
+++ b/Block/Adminhtml/Order/View/Custom.php
@@ -1,22 +1,26 @@
 <?php
 namespace Divido\DividoFinancing\Block\Adminhtml\Order\View;
 
+use Divido\DividoFinancing\Exceptions\MessageValidationException;
 use Divido\DividoFinancing\Helper\Data;
 
 class Custom extends \Magento\Backend\Block\Template
 {
     private $helper;
     private $coreRegistry;
+    private $logger;
 
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Registry $registry,
         \Divido\DividoFinancing\Helper\Data $helper,
+        \Divido\DividoFinancing\Logger\Logger $logger,
         array $data = []
     ) {
     
         $this->helper = $helper;
         $this->coreRegistry = $registry;
+        $this->logger = $logger;
         parent::__construct($context, $data);
     }
 
@@ -55,8 +59,15 @@ class Custom extends \Magento\Backend\Block\Template
                 if(array_key_exists($application->lender->app_name, Data::REFUND_CANCEL_REASONS)){
                     $cancellation['reasons'] = Data::REFUND_CANCEL_REASONS[$application->lender->app_name];
                 }
-            } catch (\Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException $_){
-                $cancellation['notification'] = __("It appears the cancellation was created with a different API key to the one currently in use. Pleae revert to that API Key if you wish to notify the lender");
+            } catch (\Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException $e){
+                $this->logger->error(sprintf("Merchant API bad response exception: %s", $e->getMessage()));
+                $cancellation['notification'] = __("It appears the cancellation was created with a different API key to the one currently in use. Please revert to that API Key if you wish to notify the lender");
+            } catch(MessageValidationException $e){
+                $this->logger->error(sprintf("Refund Validation error: %s", $e->getMessage()));
+                $cancellation['notification'] = "Error validating application information";
+            } catch(\Exception $e){
+                $this->logger->error(sprintf("Unexpected error: %s", $e->getMessage()));
+                $cancellation['notification'] = "An unknown error has occurred";
             }
 
         }

--- a/Exceptions/MessageValidationException.php
+++ b/Exceptions/MessageValidationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Divido\DividoFinancing\Exceptions;
+
+use Exception;
+
+class MessageValidationException extends Exception{
+
+}

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -446,12 +446,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function creditRequest($planId, $depositAmount, $email, $quoteId = null)
     {
-        $secret = $this->config->getValue(
-            'payment/divido_financing/secret',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        );
 
-        $quote       = $this->cart->getQuote();
+        $quote = $this->cart->getQuote();
         if ($quoteId != null) {
             $this->_objectManager = \Magento\Framework\App\ObjectManager::getInstance();
             $quote = $this->_objectManager->create('Magento\Quote\Model\Quote')->load($quoteId);
@@ -572,8 +568,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
                 ]
             );
-
+        
         $hmac = null;
+        $secret = $this->config->getValue(
+            'payment/divido_financing/secret',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
         if(!empty($secret)){
             $hmac = $this->create_signature(json_encode($application->getPayload()), $secret);
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -15,6 +15,7 @@ use Divido\DividoFinancing\Helper\EndpointHealthCheckTrait;
 use Divido\DividoFinancing\Model\RefundItems;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\ClientFactory as GuzzleClientFactory;
+use Laminas\Diactoros\RequestFactory as LaminasRequestFactory;
 use Divido\DividoFinancing\Proxies\MerchantApiPubProxy;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
@@ -66,6 +67,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     private $localeResolver;
     private $clientFactory;
     private $merchantApiProxy;
+    private $requestFactory;
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
@@ -78,7 +80,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         UrlInterface $urlBuilder,
         ProductFactory $productFactory,
         \Magento\Framework\Locale\Resolver $localeResolver,
-        GuzzleClientFactory $clientFactory
+        GuzzleClientFactory $clientFactory,
+        LaminasRequestFactory $requestFactory
     ) {
 
         $this->config         = $scopeConfig;
@@ -92,6 +95,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->productFactory = $productFactory;
         $this->localeResolver = $localeResolver;
         $this->clientFactory = $clientFactory;
+        $this->requestFactory = $requestFactory;
     }
 
     /**
@@ -137,6 +141,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
             $this->merchantApiProxy = new MerchantApiPubProxy(
                 $client,
+                $this->requestFactory,
                 $apiKey,
                 $this->logger
             );

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1350,7 +1350,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $refundAmount = 0;
         /** @var \Divido\DividoFinancing\Model\RefundItem $ri */
         foreach($refundItems as $ri){
-            $refundAmount = $ri->getAmount() * $ri->getQuantity();
+            $refundAmount += $ri->getAmount() * $ri->getQuantity();
         }
         return $refundAmount;
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -575,27 +575,28 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
         try {
             $responseObj = $this->getMerchantApiProxy()->postApplication($application, $hmac);
-
-            if ($this->debug()){
-                $debug = $responseObj->data;
-                unset($debug->applicants);
-                $this->logger->info("Application Payload: ".serialize($debug));
-            }
-            $result_id = $responseObj->data->id;
-            $result_redirect = $responseObj->data->urls->application_url;
-            
-            $lookupModel = $this->lookupFactory->create();
-            $lookupModel->load($quoteId, 'quote_id');
-            $lookupModel->setData('quote_id', $quoteId);
-            $lookupModel->setData('salt', $salt);
-            $lookupModel->setData('deposit_value', $deposit);
-            $lookupModel->setData('proposal_id', $result_id);
-            $lookupModel->setData('initial_cart_value', $grandTotal);
-            $lookupModel->save();
-            return $result_redirect;
         } catch (\Exception $e) {
             throw new \Magento\Framework\Exception\LocalizedException(__($e->getMessage()));
         }
+        
+        if ($this->debug()){
+            $debug = $responseObj->data;
+            unset($debug->applicants);
+            $this->logger->info("Application Payload: ".serialize($debug));
+        }
+        $result_id = $responseObj->data->id;
+        $result_redirect = $responseObj->data->urls->application_url;
+        
+        $lookupModel = $this->lookupFactory->create();
+        $lookupModel->load($quoteId, 'quote_id');
+        $lookupModel->setData('quote_id', $quoteId);
+        $lookupModel->setData('salt', $salt);
+        $lookupModel->setData('deposit_value', $deposit);
+        $lookupModel->setData('proposal_id', $result_id);
+        $lookupModel->setData('initial_cart_value', $grandTotal);
+        $lookupModel->save();
+        return $result_redirect;
+        
     }
 
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -29,7 +29,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CALLBACK_PATH      = 'rest/V1/divido/update/';
     const REDIRECT_PATH      = 'divido/financing/success/';
     const CHECKOUT_PATH      = 'checkout/';
-    const VERSION            = '2.10.0';
+    const VERSION            = '2.10.1';
     const WIDGET_LANGUAGES   = ["en", "fi" , "no", "es", "da", "fr", "de", "pe"];
     const SHIPPING           = 'SHPNG';
     const DISCOUNT           = 'DSCNT';

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -161,9 +161,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get Finance Platform Environment function
      *
-     *  @param [string] $api_key - The platform API key.
+     *  @return string the tenancy environment
      */
-    public function getPlatformEnv()
+    public function getPlatformEnv() :string
     {
         $environmentURl = $this->getEnvironmentUrl();
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1014,14 +1014,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     protected function getPlans()
     {
-        $finances = false;
-        if (false === $finances) {
-            try {
-                $responseObj = $this->getMerchantApiProxy()->getFinancePlans();
-                return $responseObj->data;
-            } catch (Exception $e) {
-                return [];
-            }
+        try {
+            $responseObj = $this->getMerchantApiProxy()->getFinancePlans();
+            return $responseObj->data;
+        } catch (\Exception $e) {
+            return [];
         }
     }
     public function setFulfilled($application_id, $order_total, $shipping_method = null, $tracking_numbers = null)

--- a/Model/CreditRequest.php
+++ b/Model/CreditRequest.php
@@ -50,6 +50,7 @@ class CreditRequest implements CreditRequestInterface
     private $resultJsonFactory;
     private $eventManager;
     private $orderCollection;
+    private $resourceConnection;
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
@@ -63,7 +64,8 @@ class CreditRequest implements CreditRequestInterface
         \Divido\DividoFinancing\Model\LookupFactory $lookupFactory,
         \Divido\DividoFinancing\Logger\Logger $logger,
         \Magento\Framework\Event\Manager $eventManager,
-        \Magento\Sales\Model\ResourceModel\Order\Collection $orderCollection
+        \Magento\Sales\Model\ResourceModel\Order\Collection $orderCollection,
+        \Magento\Framework\App\ResourceConnection $resourceConnection
     ) {
         $this->req    = $request;
         $this->quote = $quote;
@@ -77,6 +79,7 @@ class CreditRequest implements CreditRequestInterface
         $this->resourceInterface = $resourceInterface;
         $this->eventManager = $eventManager;
         $this->orderCollection = $orderCollection;
+        $this->resourceConnection = $resourceConnection;
     }
 
     /**
@@ -189,11 +192,13 @@ class CreditRequest implements CreditRequestInterface
             $lookup->save();
         }
 
+        $salesOrderPaymentTableNameWithPrefix = $this->resourceConnection->getTableName('sales_order_payment');
+
         //Fetch latest Divido order for quote ID
         $this->orderCollection->addAttributeToFilter('quote_id', $quoteId);
         $this->orderCollection->getSelect()
             ->join(
-                ["sop" => "sales_order_payment"],
+                ["sop" => $salesOrderPaymentTableNameWithPrefix],
                 'main_table.entity_id = sop.parent_id',
                 array('method')
             )

--- a/Model/RefundItems.php
+++ b/Model/RefundItems.php
@@ -20,11 +20,11 @@ class RefundItems implements \Iterator
         $this->key = 0;
     }
 
-    public function current(){
+    public function current() :RefundItem {
         return $this->refundItems[$this->key];
     }
 
-    public function key(){
+    public function key() :int {
         return $this->key;
     }
 
@@ -40,7 +40,7 @@ class RefundItems implements \Iterator
         return isset($this->refundItems[$this->key]);
     }
 
-    public function addRefundItem(RefundItem $item){
+    public function addRefundItem(RefundItem $item) :void{
         $this->refundItems[] = $item;
     }
 

--- a/Observer/CancelObserver.php
+++ b/Observer/CancelObserver.php
@@ -33,7 +33,7 @@ class CancelObserver implements ObserverInterface
 
             $reason = (isset($params['pbd_reason'])) ? $params['pbd_reason'] : null;
             
-            if(array_key_exists($application['lender']['app_name'], Data::REFUND_CANCEL_REASONS) && $reason == null){
+            if(array_key_exists($application->lender->app_name, Data::REFUND_CANCEL_REASONS) && $reason == null){
                 throw new CancelException(__("You must specify a cancellation reason"));
             }
         

--- a/Observer/ConfigChangeObserver.php
+++ b/Observer/ConfigChangeObserver.php
@@ -39,11 +39,10 @@ class ConfigChangeObserver implements ObserverInterface
     private function environmentHealthCheck(): bool
     {
         // Get result of health check
-        $response = $this->dataHelper->request('GET', 'health');
-        $healthCheckResult = $response->getBody()->getContents();
+        $health = $this->dataHelper->getMerchantApiProxy()->getHealth();
 
         // If not ok, show an error message
-        if($healthCheckResult !== 'OK'){
+        if($health === false){
             $this->messageManager->addErrorMessage('Error, could not validate the health of endpoint, please check the "environment_url" setting');
             return false;
         }

--- a/Observer/ConfigChangeObserver.php
+++ b/Observer/ConfigChangeObserver.php
@@ -38,20 +38,12 @@ class ConfigChangeObserver implements ObserverInterface
      */
     private function environmentHealthCheck(): bool
     {
-        try {
-            $sdkClient = $this->dataHelper->getSdk();
-        } catch (RuntimeException $e) {
-            $this->messageManager->addErrorMessage('Error while getting client to check health of endpoint');
-            return false;
-        }
-
         // Get result of health check
-        $healthCheckResult = $this->dataHelper->getEndpointHealthCheckResult(
-            $sdkClient
-        );
+        $response = $this->dataHelper->request('GET', 'health');
+        $healthCheckResult = $response->getBody()->getContents();
 
         // If not ok, show an error message
-        if($healthCheckResult !== true){
+        if($healthCheckResult !== 'OK'){
             $this->messageManager->addErrorMessage('Error, could not validate the health of endpoint, please check the "environment_url" setting');
             return false;
         }

--- a/Observer/RefundObserver.php
+++ b/Observer/RefundObserver.php
@@ -34,16 +34,16 @@ class RefundObserver implements ObserverInterface
             
         if ($code == Data::PAYMENT_METHOD && $autoRefund) {
             $application = $this->helper->getApplicationFromOrder($order);
-            $refundable = $application['amounts']['refundable_amount'];
+            $refundable = $application->amounts->refundable_amount;
 
             $refundItems = $this->generateRefundItems($params['creditmemo'], $order->getItems());
 
             $amount = $this->helper->getRefundAmount($refundItems);
 
             $partialRefund = ($amount < $order->getBaseGrandTotal());
-            $partiallyRefundable = (in_array($application['lender']['app_name'], Data::NON_PARTIAL_LENDERS))
+            $partiallyRefundable = (in_array($application->lender->app_name, Data::NON_PARTIAL_LENDERS))
                 ? 0
-                : $application['amounts']['refundable_amount'] - $application['finance_plan']['credit_amount']['minimum_amount'];
+                : $application->amounts->refundable_amount - $application->finance_plan->credit_amount->minimum_amount;
             if($partialRefund && $amount > $partiallyRefundable){
                 throw new RefundException(__("Refund amount exceeds partial refund limit"));
             }
@@ -54,7 +54,7 @@ class RefundObserver implements ObserverInterface
 
             $this->logger->info('PBD Refund Triggered', ['Quote' => $order->getQuoteId(), 'request' => $params]);
 
-            if(array_key_exists($application['lender']['app_name'], Data::REFUND_CANCEL_REASONS) && !isset($params['pbd_refund_reason'])){
+            if(array_key_exists($application->lender->app_name, Data::REFUND_CANCEL_REASONS) && !isset($params['pbd_refund_reason'])){
                 throw new RefundException(__("You must specify a refund reason"));
             }
             $reason = $params['pbd_refund_reason'] ?? null;

--- a/Proxies/MerchantApiPubProxy.php
+++ b/Proxies/MerchantApiPubProxy.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Divido\DividoFinancing\Proxies;
+
+use Psr\Http\Client\ClientInterface;
+use Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException;
+use Divido\MerchantSDK\Models\Application;
+use Divido\MerchantSDK\Models\ApplicationActivation;
+use Divido\MerchantSDK\Models\ApplicationCancellation;
+use Divido\MerchantSDK\Models\ApplicationRefund;
+use Divido\DividoFinancing\Logger\Logger;
+use GuzzleHttp\Psr7\Response;
+
+
+/**
+ * A proxy between the Merchant API Pub and the HttpApiWrapper
+ */
+class MerchantApiPubProxy{
+
+    const HTTP_METHOD_POST = 'POST';
+    const HTTP_METHOD_GET = 'GET';
+    const HTTP_METHOD_PATCH = 'PATCH';
+
+    const PATHS = [
+        self::HTTP_METHOD_GET => [
+            'APPLICATION' => '/applications/%s',
+            'HEALTH' => '/health',
+            'PLANS' => '/finance-plans',
+            'ENVIRONMENT' => '/environment'
+        ],
+        self::HTTP_METHOD_POST => [
+            'APPLICATION' => '/applications',
+            'ACTIVATION' => '/applications/%s/activations',
+            'REFUND' => '/applications/%s/refunds',
+            'CANCELLATION' => '/applications/%s/cancellations'
+        ],
+        self::HTTP_METHOD_PATCH => [
+            'APPLICATION' => '/applications/%s'
+        ]
+    ];
+
+    const HEADER_KEYS_API = 'X-DIVIDO-API-KEY';
+    const HEADER_KEYS_SHARED_SECRET = 'X-Divido-Hmac-Sha256';
+    
+    private ClientInterface $client;
+
+    private string $apiKey;
+
+    private Logger $logger;
+
+    public function __construct(
+        ClientInterface $client,
+        string $apiKey,
+        Logger $logger
+    ){
+        $this->client = $client;
+        $this->apiKey = $apiKey;
+        $this->logger = $logger;
+    }
+
+    public function request(
+        string $method,
+        string $endpoint,
+        array $additionalParams = []
+    ): Response {
+
+        $params = array_merge_recursive([
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                self::HEADER_KEYS_API => $this->apiKey
+            ]
+        ], $additionalParams);
+
+        try{
+            $response = $this->client->request(
+                $method,
+                $endpoint,
+                $params
+            );
+        } catch (\Exception $e) {
+            $this->logger->error(
+                sprintf("Received the following error: %s", $e->getMessage()),
+                ['params' => $params, 'endpoint' => $endpoint]
+            );
+
+            throw $e;
+        }
+
+        return $response;
+        
+    }
+
+    /**
+     * Makes a request to the Merchant API Pub health endpoint and returns true if API is healthy
+     *
+     * @return boolean
+     */
+    public function getHealth():bool{
+
+        $response = $this->request(self::HTTP_METHOD_GET, self::PATHS[self::HTTP_METHOD_GET]['HEALTH']);
+        
+        return $response->getBody()->getContents() === 'OK';
+    }
+
+    /**
+     * Makes a request to the environment endpoint, and returns a json
+     * object of the response body
+     *
+     * @return object
+     */
+    public function getEnvironment():object{
+
+        $response = $this->request(self::HTTP_METHOD_GET, self::PATHS[self::HTTP_METHOD_GET]['ENVIRONMENT']);
+        
+        return $this->getResponseBodyObj($response);
+    }
+
+    /**
+     * Makes a request to the finance plans endpoint, and returns a json
+     * object of the response body
+     *
+     * @return object
+     */
+    public function getFinancePlans() :object{
+        $response = $this->request(self::HTTP_METHOD_GET, self::PATHS[self::HTTP_METHOD_GET]['PLANS']);
+        
+        return $this->getResponseBodyObj($response);
+    }
+
+    public function getApplication(string $applicationId) :object{
+        $path = sprintf(
+            self::PATHS[self::HTTP_METHOD_GET]['APPLICATION'],
+            $applicationId
+        );
+
+        $response = $this->request(self::HTTP_METHOD_GET, $path);
+        
+        return $this->getResponseBodyObj($response);
+    }
+
+    /**
+     * Makes a request to create an application, and returns a json
+     * object of the response body
+     *
+     * @param Application $application
+     * @param string|null $hmac
+     * @return object
+     */
+    public function postApplication(Application $application, ?string $hmac = null): object{
+
+        $body = $application->getJsonPayload();
+
+        $params = ['body' => $body];
+
+        if ($hmac !== null) {
+            $params['headers'][self::HEADER_KEYS_SHARED_SECRET] = $hmac;
+        }
+        
+        $response = $this->request(
+            self::HTTP_METHOD_POST,
+            self::PATHS[self::HTTP_METHOD_POST]['APPLICATION'],
+            $params
+        );
+
+        return $this->getResponseBodyObj($response);
+    }
+
+    /**
+     * Makes a request to create an activation, and returns a json
+     * object of the response body
+     *
+     * @param string $applicationId
+     * @param ApplicationActivation $activation
+     * @return object
+     */
+    public function postActivation(string $applicationId, ApplicationActivation $activation): object{
+
+        $body = $activation->getJsonPayload();
+
+        $path = sprintf(
+            self::PATHS[self::HTTP_METHOD_POST]['ACTIVATION'],
+            $applicationId
+        );
+
+        $response = $this->request(self::HTTP_METHOD_POST, $path, ['body' => $body]);
+
+        return $this->getResponseBodyObj($response);
+    }
+
+    /**
+     * Makes a request to create a cancellation, and returns a json
+     * object of the response body
+     *
+     * @param string $applicationId
+     * @param ApplicationCancellation $cancellation
+     * @return object
+     */
+    public function postCancellation(string $applicationId, ApplicationCancellation $cancellation): object{
+
+        $path = sprintf(
+            self::PATHS[self::HTTP_METHOD_POST]['CANCELLATION'],
+            $applicationId
+        );
+
+        $body = $cancellation->getJsonPayload();
+
+        $response = $this->request(self::HTTP_METHOD_POST, $path, ['body' => $body]);
+
+        return $this->getResponseBodyObj($response);
+    }
+
+    /**
+     * Makes a request to create a refund, and returns a json
+     * object of the response body
+     *
+     * @param string $applicationId
+     * @param ApplicationRefund $refund
+     * @return object
+     */
+    public function postRefund(string $applicationId, ApplicationRefund $refund): object{
+        
+        $path = sprintf(
+            self::PATHS[self::HTTP_METHOD_POST]['REFUND'],
+            $applicationId
+        );
+
+        $body = $refund->getJsonPayload();
+        $response = $this->request(self::HTTP_METHOD_POST, $path, ['body' => $body]);
+
+        return $this->getResponseBodyObj($response);
+    }
+
+    
+    /**
+     * Makes a request to update an application, and returns a json
+     * object of the response body
+     *
+     * @param Application $application
+     * @return object
+     */
+    public function updateApplication(Application $application): object{
+
+        $body = $application->getJsonPayload();
+
+        $path = sprintf(
+            self::PATHS[self::HTTP_METHOD_PATCH]['APPLICATION'],
+            $application->getId()
+        );
+
+        $response = $this->request(self::HTTP_METHOD_PATCH, $path, ['body' => $body]);
+
+        return $this->getResponseBodyObj($response);
+    }
+
+    /**
+     * Attempts to turn the body of the response into a json object
+     *
+     * @param Response $response
+     * @return object
+     */
+    private function getResponseBodyObj(Response $response):object{
+        return json_decode(
+            $response->getBody()->getContents(), 
+            false, 
+            512, 
+            JSON_THROW_ON_ERROR
+        );
+    }
+}

--- a/Proxies/MerchantApiPubProxy.php
+++ b/Proxies/MerchantApiPubProxy.php
@@ -73,15 +73,11 @@ class MerchantApiPubProxy{
         ], $additionalParams);
 
         try{
-            $response = $this->client->request(
-                $method,
-                $endpoint,
-                $params
-            );
+            $response = $this->client->request($method, $endpoint, $params);
         } catch (\Exception $e) {
             $this->logger->error(
-                sprintf("Received the following error: %s", $e->getMessage()),
-                ['params' => $params, 'endpoint' => $endpoint]
+                sprintf("MerchantApiPubProxy - Received the following error: %s", $e->getMessage()),
+                ['method' => $method, 'endpoint' => $endpoint]
             );
 
             throw $e;

--- a/Schemas/activation.json
+++ b/Schemas/activation.json
@@ -1,0 +1,42 @@
+{
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type":"string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "status": {
+            "type":"string"
+          },
+          "reference": {
+            "type": ["string", "null"]
+          },
+          "data": {
+            "type": "array"
+          },
+          "comment": {
+            "type": ["string", "null"]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "amount",
+          "status"
+        ]
+      }
+    },
+    "required": [
+      "data"
+    ]
+  }

--- a/Schemas/application.json
+++ b/Schemas/application.json
@@ -1,0 +1,224 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type":"string"
+        },
+        "token": {
+          "type":["string", "null"]
+        },
+        "finalised": {
+          "type":["boolean","null"]
+        },
+        "finalisation_required": {
+          "type": ["boolean", "null"]
+        },
+        "current_status": {
+          "type": "string"
+        },
+        "lender_reference": {
+          "type": ["string", "null"]
+        },
+        "lender_loan_reference": {
+          "type": ["string", "null"]
+        },
+        "order_items": {
+          "type":"array",
+          "items": {
+              "type": "object",
+              "properties": {
+                  "name":{
+                      "type": "string"
+                  },
+                  "quantity": {
+                      "type":"integer"
+                  },
+                  "price": {
+                      "type":"integer"
+                  },
+                  "sku": {
+                      "type": "string"
+                  }
+              },
+              "required":[
+                  "name",
+                  "quantity",
+                  "price"
+              ]
+          }
+        },
+        "applicants":{
+          "type": "array"
+        },
+        "amounts": {
+          "type": "object",
+          "properties": {
+              "activatable_amount": {
+                  "type": "integer"
+              },
+              "activated_amount": {
+                  "type": "integer"
+              },
+              "cancelable_amount": {
+                  "type": "integer"
+              },
+              "cancelled_amount": {
+                  "type": "integer"
+              },
+              "original_credit_amount": {
+                  "type": "integer"
+              },
+              "current_credit_amount": {
+                  "type": "integer"
+              },
+              "deposit_amount": {
+                  "type": "integer"
+              },
+              "monthly_payment_amount": {
+                  "type": "integer"
+              },
+              "purchase_price_amount": {
+                  "type": "integer"
+              },
+              "refundable_amount": {
+                  "type": "integer"
+              },
+              "refunded_amount": {
+                  "type": "integer"
+              },
+              "total_repayable_amount": {
+                  "type": "integer"
+              }
+          },
+          "required": [
+              "activatable_amount",
+              "activated_amount",
+              "cancelable_amount",
+              "cancelled_amount",
+              "original_credit_amount",
+              "current_credit_amount",
+              "deposit_amount",
+              "monthly_payment_amount",
+              "purchase_price_amount",
+              "refundable_amount",
+              "refunded_amount",
+              "total_repayable_amount"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "activation_status": {
+          "type": ["string", "null"]
+        },
+        "deposit_status": {
+          "type": ["string", "null"]
+        },
+        "merchant_reference": {
+          "type": ["string", "null"]
+        },
+        "urls": {
+          "type": "object",
+          "properties": {
+              "merchant_success_redirect_url": {
+                  "type": ["string", "null"]
+              },
+              "merchant_redirect_url": {
+                  "type": ["string", "null"]
+              },
+              "merchant_checkout_url": {
+                  "type": ["string", "null"]
+              },
+              "merchant_webhook_url": {
+                  "type": ["string", "null"]
+              },
+              "merchant_response_url": {
+                  "type": ["string", "null"]
+              },
+              "application_url": {
+                  "type": ["string", "null"]
+              }
+          },
+          "required": [
+              "merchant_success_redirect_url",
+              "merchant_checkout_url",
+              "merchant_response_url",
+              "application_url"
+          ]
+        },
+        "country": {
+          "type": "object",
+          "properties": {
+              "id": {
+                  "type": "string"
+              },
+              "name": {
+                  "type": "string"
+              }
+          }
+        },
+        "currency": {
+          "type": "object",
+          "properties": {
+              "id": {
+                  "type": "string"
+              }
+          }
+        },
+        "language": {
+          "type": "object",
+          "properties": {
+              "id": {
+                  "type": "string"
+              },
+              "name": {
+                  "type": "string"
+              }
+          }
+        },
+        "deposits": {
+          "type": "array"
+        },
+        "finance_plan": {
+          "type": "object"
+        },
+        "lender": {
+          "type": "object"
+        },
+        "merchant": {
+          "type": "object"
+        },
+        "merchant_channel": {
+          "type": "object"
+        },
+        "application_histories": {
+          "type": "array"
+        },
+        "submissions": {
+          "type": "array"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "token",
+        "current_status",
+        "order_items",
+        "amounts",
+        "applicants",
+        "urls"
+      ]
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/Schemas/cancellation.json
+++ b/Schemas/cancellation.json
@@ -1,0 +1,42 @@
+{
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type":"string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "status": {
+            "type":"string"
+          },
+          "reference": {
+            "type": ["string", "null"]
+          },
+          "data": {
+            "type": "array"
+          },
+          "comment": {
+            "type": ["string", "null"]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "amount",
+          "status"
+        ]
+      }
+    },
+    "required": [
+      "data"
+    ]
+  }

--- a/Schemas/environment.json
+++ b/Schemas/environment.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "environment": {
+          "type":"string"
+        }
+      },
+      "required": [
+        "environment"
+      ]
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/Schemas/finance-plans.json
+++ b/Schemas/finance-plans.json
@@ -1,0 +1,49 @@
+{
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object"
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "country": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "currency": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "active",
+          "description"
+        ]
+      }
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/Schemas/refund.json
+++ b/Schemas/refund.json
@@ -1,0 +1,42 @@
+{
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type":"string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "status": {
+            "type":"string"
+          },
+          "reference": {
+            "type": ["string", "null"]
+          },
+          "data": {
+            "type": "array"
+          },
+          "comment": {
+            "type": ["string", "null"]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "amount",
+          "status"
+        ]
+      }
+    },
+    "required": [
+      "data"
+    ]
+  }

--- a/Traits/ValidationTrait.php
+++ b/Traits/ValidationTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Divido\DividoFinancing\Traits;
+
+use Divido\DividoFinancing\Exceptions\MessageValidationException;
+use \Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException;
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Validator;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+
+trait ValidationTrait
+{
+
+    /**
+     * Checks the status code and validates the response payload against the schema
+     *
+     * @param ResponseInterface $response
+     * @param string $schema
+     * @param integer $expectedStatusCode
+     * @return object
+     */
+    public function validateResponse(ResponseInterface $response, string $schema, int $expectedStatusCode = 200): object
+    {
+        $this->checkStatusCode($response, $expectedStatusCode);
+        return $this->validateMessage($response, $schema);
+    }
+
+    /**
+     * Checks the status code of the response is the same as the expected code
+     *
+     * @param ResponseInterface $response
+     * @param integer $expectedStatusCode
+     * @return void
+     * @throws MerchantApiBadResponseException if response status code doesn't match expected
+     */
+    public function checkStatusCode(ResponseInterface $response, int $expectedStatusCode = 200) :void{
+        if($response->getStatusCode() !== $expectedStatusCode){
+            throw new MerchantApiBadResponseException(
+                sprintf(
+                    "Expected status code %d: Received %d.",
+                    $expectedStatusCode,
+                    $response->getStatusCode()
+                ),
+                json_decode($response->getBody()->getContents(), true)['code'] ?? 500001,
+                json_decode($response->getBody()->getContents(), true)['context'] ?? ''
+            );
+        }
+    }
+
+    /**
+     * Ensures the 
+     *
+     * @param MessageInterface $message
+     * @param string $schema
+     * @return object
+     * @throws \Exception if schema could not be found
+     * @throws MessageValidationException if body does not match supplied schema
+     */
+    public function validateMessage(MessageInterface $message, string $schema) :object
+    {
+        $validator = new Validator();
+        $raw = (string) $message->getBody();
+        
+        $body = json_decode($raw, null, 512, JSON_THROW_ON_ERROR);
+
+        $path = sprintf('%s/../Schemas/%s.json', __DIR__, $schema);
+        $realPath = realpath($path);
+        if ($realPath === false) {
+            throw new \Exception("Could not find relevant schema file ({$path})");
+        }
+        // validate
+        $validator->validate(
+            $body,
+            ['$ref' => "file://{$path}"],
+            Constraint::CHECK_MODE_APPLY_DEFAULTS
+        );
+
+        if (!$validator->isValid()) {
+            throw new MessageValidationException (
+                implode(
+                    " | ", 
+                    array_map(
+                        function($error){
+                            return sprintf("%s: %s", $error['property'], $error['message']);
+                        },
+                        $validator->getErrors()
+                    )
+                )
+            );
+        }
+
+        return $body;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "divido/merchant-sdk": "^3",
-        "laminas/laminas-diactoros": "^3.3"
+        "laminas/laminas-diactoros": ">=2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require": {
         "divido/merchant-sdk": "^3",
-        "laminas/laminas-diactoros": ">=2"
+        "laminas/laminas-diactoros": ">=2",
+        "justinrainbow/json-schema": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "divido/merchant-sdk": "^3.0.0"
+        "divido/merchant-sdk": "^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "license": [
         "OSL-3.0"
     ],

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,18 @@
         }
     },
     "require": {
-        "divido/merchant-sdk": "^3"
+        "divido/merchant-sdk": "^3",
+        "laminas/laminas-diactoros": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "magento/core": "*",
         "magento/community-edition": "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true,
+            "magento/magento-composer-installer": true,
+            "magento/composer-dependency-version-audit-plugin": true
+        }
     }
 }


### PR DESCRIPTION
Erm, initially started as a PR to just make the RefundItems class PHP 8 compatible, by giving the functions the required return types. But then the Merchant API Pub SDK was being a pain with `php-http/discovery` and the need for a Request Factory, so I just decided to cut the whole Client handling side out of my interactions with the Merchant API SDK and used the GuzzleFactory(?) method referenced in the [Magento docs](https://developer.adobe.com/commerce/php/tutorials/backend/create-api-integration/) instead.

disclaimer: I have not tried to improve the code other than architecturally (and bug fixes). This month's theme will be code coverage for the plugin (which is currently non-existent), so I'll try to address those issues throughout that process.

This PR:
- Makes RefundItems PHP 8 compatible
- Removes the use of the SDK Client facilities in favour of Guzzle (part of Magento base)
- Fixes issue with Refund requests just partially refunding the last order item
- Fixes potential issue with prefixed tables on order completion

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [ ] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] The plugin version in `composer.json` has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
- [ ] Ensure logging is kept to a minimum, does not include PII, and is set to the pertinent level
