### PR TITLE
chore: LM2-2242 shipping address

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -460,9 +460,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $shippingAddress = $this->getApplicationAddressFromMagentoAddress($shipAddr);
         $billingAddress  = $this->getApplicationAddressFromMagentoAddress($billingAddr);
 
-        if (!empty($email) && !$quote->getCustomerEmail()) {
+        if (!empty($email) && empty($quote->getCustomerEmail())) {
             $quote->setCustomerEmail($email);
             $this->quoteRepository->save($quote);
+        }
+
+        if(empty($email)){
+            $email = $quote->getCustomerEmail();
         }
 
         $customer = [
@@ -472,7 +476,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             'lastName'          => $billingAddr->getLastName(),
             'country'           => $billingAddr->getCountry(),
             'postcode'          => $billingAddr->getPostcode(),
-            'email'             => $quote->getCustomerEmail(),
+            'email'             => $email,
             'phoneNumber'       => $this->stripWhite($billingAddr->getTelephone()),
             'addresses'         => [$billingAddress],
             'shippingAddress'   => $shippingAddress,

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -464,21 +464,18 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 $quote->save();
             }
         } else {
-            if ($existingEmail = $quote->getCustomerEmail()) {
-                $email = $existingEmail;
-            }
+            $email = $quote->getCustomerEmail();
         }
-        $store = $this->storeManager->getStore();
 
         $customer = [
             'title'             => '',
-            'firstName'         => $shipAddr->getFirstName(),
-            'middleNames'       => $shipAddr->getMiddleName(),
-            'lastName'          => $shipAddr->getLastName(),
+            'firstName'         => $billingAddr->getFirstName(),
+            'middleNames'       => $billingAddr->getMiddleName(),
+            'lastName'          => $billingAddr->getLastName(),
             'country'           => $billingAddr->getCountry(),
-            'postcode'          => $shipAddr->getPostcode(),
+            'postcode'          => $billingAddr->getPostcode(),
             'email'             => $email,
-            'phoneNumber'       => $this->stripWhite($shipAddr->getTelephone()),
+            'phoneNumber'       => $this->stripWhite($billingAddr->getTelephone()),
             'addresses'         => [$billingAddress],
             'shippingAddress'   => $shippingAddress,
         ];


### PR DESCRIPTION
Gives [continuity](https://github.com/dividohq/finance-plugin-woocommerce/commit/20d14a1d736086c8fdf37764341018b487918fd0) to the [details](https://github.com/dividohq/finance-plugin-shopify-integration-v3/commit/8ac58d4572a17a9f5597da0e8f711854f5037be9) we [send](https://github.com/dividohq/finance-plugin-prestashop/commit/57204dec2328bdce6f84adf0060fec7bddb81f4b) the Merchant API from plugins across all e-commerce platforms.
Also sends the customer details from the billing address, rather than the shipping address

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [ ] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] The plugin version in `composer.json` has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
- [ ] Ensure logging is kept to a minimum, does not include PII, and is set to the pertinent level
