### PR TITLE
chore: bump composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "divido/divido-magento2",
     "description": "Powered by Divido financing gateway",
     "type": "magento2-module",
-    "version": "2.10.2",
+    "version": "3.0.0",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Bumps the version in composer.json to v3.0.0

### PR CHECKLIST

- [ ] Ensure any new strings have been translated for import
- [ ] Import new translations via `integrations-magento2`'s `make script-install-languages` command
- [ ] The plugin version (currently as a const in the `Data.php`) has been updated
- [ ] The plugin version in `composer.json` has been updated
- [ ] Tests have been added for any new functionality via `integrations-magento2`'s `make test` command
- [ ] Ensure logging is kept to a minimum, does not include PII, and is set to the pertinent level
